### PR TITLE
Propagate errors and log

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,12 +190,14 @@ Target Events
 - starting
 - chain
 - complete
+- error
 
 Chain Events
 
 - command dispatching
 - command complete
 - complete
+- error
 
 ## Hacking
 

--- a/bin/runner.js
+++ b/bin/runner.js
@@ -36,12 +36,8 @@ var batch = new Batch(batchOptions);
 logger.attach(batch);
 batch.run(function batchComplete(err) {
 	if (err) {
-		if (/Error/.test(err.toString())) {
-			logger.error(err.message);
-		}
-
-		logger.log(err);
+		logger.log('Run failed');
+	} else {
+		logger.log('Run successful');
 	}
-
-	logger.log('done');
 });

--- a/examples/erroring-test.js
+++ b/examples/erroring-test.js
@@ -1,0 +1,8 @@
+/* global $ */
+/* global chain */
+/* global server */
+
+$('echo hello')
+	.and('jhvfsdjhsdfecho world');
+
+chain('echo running on ' + server);

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -71,13 +71,16 @@ Batch.prototype.run = function run(callback) {
 	this.loadScripts();
 
 	async[asyncMode](this.targets, function runTarget(target, cb) {
-		target.run(cb);
+		target.run(function (err) {
+			cb(err);
+		});
 	}, function runAllTargets(err) {
 		if (err) {
-			return this.emit('error', err);
+			this.emit('error', err);
 		}
-
-		this.emit('complete');
+		else {
+			this.emit('complete');
+		}
 		callback(err);
 	}.bind(this));
 };

--- a/lib/loggers/console.js
+++ b/lib/loggers/console.js
@@ -29,6 +29,10 @@ var consoleLogger = {
 					chain.on('complete', function () {
 						self.log('Chain Complete');
 					});
+
+					chain.on('error', function (err) {
+						self.error(err.stack.red);
+					});
 				});
 
 				target.on('starting', function () {
@@ -40,6 +44,14 @@ var consoleLogger = {
 					self.log(successMessage.green);
 				});
 
+				target.on('error', function (err) {
+					if (target.local()) {
+						self.error('Local target errored'.red);
+					} else {
+						self.error(('Target errored: ' + target.server()).red);
+					}
+				});
+
 			});
 		});
 
@@ -48,7 +60,8 @@ var consoleLogger = {
 		});
 
 		batch.on('error', function (err) {
-			self.error(err.message.red);
+			self.error('************************************'.red);
+			self.error(('Batch errored:\n' + err.message).red);
 		});
 	}
 };

--- a/lib/loggers/teamcity.js
+++ b/lib/loggers/teamcity.js
@@ -13,6 +13,12 @@ function flowLog(flowId) {
 	console.log(teamcity.buildMessage(msg, undefined, undefined, flowId));
 }
 
+function flowError(flowId) {
+	var msg = arguments[1];
+	var err = arguments[2];
+	console.log(teamcity.buildMessage(msg, err, undefined, flowId));
+}
+
 var teamCityLogger =  {
 	name: 'TeamCity',
 	log: basicLog,
@@ -40,6 +46,10 @@ var teamCityLogger =  {
 					chain.on('complete', function () {
 						flowLog(flowId, 'Chain Complete');
 					});
+
+					chain.on('error', function (err) {
+						flowError(flowId, err.stack);
+					});
 				});
 
 				target.on('starting', function () {
@@ -50,11 +60,22 @@ var teamCityLogger =  {
 					console.log(teamcity.finishProgress(this.server()));
 				});
 
+				target.on('error', function (err) {
+					var errMsg;
+					if (target.local()) {
+						errMsg = 'Local target errored';
+					} else {
+						errMsg = 'Target errored: ' + target.server();
+					}
+					flowError(flowId, errMsg);
+				});
+
 			});
 		});
 
 		batch.on('error', function (err) {
-			self.error(err.message.red);
+			self.error('*****************************');
+			console.log(teamcity.failBuild('Batch errored:\n' + err.message));
 		});
 	}
 };

--- a/lib/target.js
+++ b/lib/target.js
@@ -63,6 +63,12 @@ Target.prototype.destroy = function destroy() {
 Target.prototype.runChains = function runChains(callback) {
 	async.eachSeries(this.chains, function runChain(chain, cb) {
 		this.emit('chain starting', chain);
+
+		chain.on('error', function (err) {
+			this.emit('error', err);
+			cb(err);
+		}.bind(this));
+
 		chain.andFinally(function chainCompleted(err) {
 			if (err) {
 				return cb(err);
@@ -71,7 +77,9 @@ Target.prototype.runChains = function runChains(callback) {
 			this.emit('chain complete');
 			return cb();
 		}.bind(this));
-	}.bind(this), callback.bind(this));
+
+
+	}.bind(this), callback);
 };
 
 Target.prototype.run = function run(callback) {
@@ -83,7 +91,7 @@ Target.prototype.run = function run(callback) {
 
 		this.emit('complete');
 		return callback();
-	});
+	}.bind(this));
 };
 
 module.exports = Target;

--- a/test/TargetSpecs.js
+++ b/test/TargetSpecs.js
@@ -198,6 +198,43 @@ describe('Target', function () {
 			});
 		});
 
+		it('should emit error when chain errors', function (done) {
+			var errorEventEmitted = false;
+			var target = new Target();
+
+			target.dispatcher = function fakeDispatcher(command, callback) {
+				callback(new Error('command errored!'));
+			};
+
+			target.addChain("echo hello");
+
+			target.on('error', function (err) {
+				errorEventEmitted = true;
+				assert.equal(err.message, 'command errored!');
+				done();
+			});
+
+			target.run(function () {});
+		});
+
+		it('should callback error when chain errors', function (done) {
+			var errorEventEmitted = false;
+			var target = new Target();
+			var errorMessage = 'command errored!';
+
+			target.dispatcher = function fakeDispatcher(command, callback) {
+				callback(new Error(errorMessage));
+			};
+
+			target.addChain('echo hello');
+
+			target.on('error', function () {}); // prevent throwing when error event not bound to
+
+			target.run(function (err) {
+				assert.equal(err.message, errorMessage);
+				done();
+			});
+		});
 	});
 
 	describe('context properties', function () {


### PR DESCRIPTION
- Errors occuring halfway through executing chains with no handling
  are passed up through to target and batch level to be returned in the
  final callback
- Error events are emitted at all levels to give visibility to loggers
