### PR TITLE
Force an exit after the batch runs

### DIFF
--- a/bin/runner.js
+++ b/bin/runner.js
@@ -37,7 +37,9 @@ logger.attach(batch);
 batch.run(function batchComplete(err) {
 	if (err) {
 		logger.log('Run failed');
+		process.exit(1);
 	} else {
 		logger.log('Run successful');
+		process.exit(0);
 	}
 });


### PR DESCRIPTION
Workaround to an  issue that the platform tool deploy is having.
where the "Batch Complete" and "Run successful" messages are followed
by a TCP error: "Error: read ECONNRESET at errnoException (net.js:901:11) at TCP.onread (net.js:556:19)"
This fails the build after it has already claimed success, for unknown reasons.

This might be a dirty hack, if there's a better way to diagnose what's going wrong let#s work on it.
