### PR TITLE
Update npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ node_js:
   - "0.10"
   - "0.8"
 
+before_install:
+  - npm update npm -g
+
 notifications:
   recipients:
     - direct-tech+travis@7digital.com


### PR DESCRIPTION
We need to update npm to support carets (^) in version numbers. This is required as node 0.8.x on Travis uses a version of npm that does not support this.

Basically I just wanted to fix the build in Travis so an ugly failing build doesn't appear in my list of repositories!

(As an aside this isn't required if you just target v0.10.x.)
